### PR TITLE
Add interface to change cluster size and steepness

### DIFF
--- a/spyclib/spaic2_defs.f90
+++ b/spyclib/spaic2_defs.f90
@@ -6,5 +6,5 @@ integer, parameter :: nr=int(rmax/dr), nasymp=int(rasymp/dr)
 double precision, parameter :: ecmin = 0.002d0
 
 ! GLOBAL PARAMS
-double precision :: rclus=11d0, drclus=0.9d0, vclus=0.2d0, fluc=0.1d0, rpot=15d0
+double precision :: vclus=0.2d0, fluc=0.1d0, rpot=15d0
 integer :: num_para=-1

--- a/spyclib/spaic2_pot2density.f90
+++ b/spyclib/spaic2_pot2density.f90
@@ -17,6 +17,9 @@ IMPLICIT NONE
   
   ! INTERFACE
 
+  double precision :: rclus
+  double precision :: drclus
+  
   ! SUBROUTINES
   public :: linsys
   public :: initialize

--- a/test.py
+++ b/test.py
@@ -5,7 +5,12 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-# Test spaic2a
-solver = spyclib.Spaic2Solver()
-solver.woodsaxon_params = np.random.rand(10)
-solver.plot()
+# Test cluster radius interface
+R = np.array([11.0, 9., 13.])
+dR = np.array([0.1, 0.9, 3.])
+
+
+for i in np.arange(3):
+    solver = spyclib.Spaic2Solver() # if this line is moved to the line prior the for-loop, this example does not segfault any more
+    print(R[i])
+    solver.cluster_radius = R[i]


### PR DESCRIPTION
This adds methods to the spyclib class that allow to set
cluster size (rclus) and cluster steepness (drclus)
variables in Fortran from within python.

 spyclib/spaic2_defs.f90:
    Remove global constant variables rclus and drclus and move them to
    spyclib/spaic2_pot2density.f90.

 spyclib/spaic2_pot2density.f90:
    Define global variables rclus and drclus.

 spyclib/spaic2_solver.py:
    - Add class variables "default_cluster_size" and
       "default_cluster_steepness".
    - Introduce three flags in the __init__ function to indicate whether
      all information to compute a potential density from woodsaxon parameters
      are defined. This is only important when a new instance of the spyclib
      class is instantiated.
    - Assign default values to cluster steepness and radius in the
      init function.
    - Add cluster_radius getter and setter to read and write to the cluster
      radius variabel rclus.
    - Add cluster_steepness getter and setter to read and write to the cluster
      steepness variabel drclus.
    - Add check before computing the cluster density parameters in the
      density_params function.

 test.py:
    - Add a sanity check to investigate potential memory problems.